### PR TITLE
Fix ImportError importing from pgi instead of gi

### DIFF
--- a/gp-saml-gui.py
+++ b/gp-saml-gui.py
@@ -2,9 +2,15 @@
 
 try:
     import gi
+    gi.require_version('Gtk', '3.0')
+    gi.require_version('WebKit2', '4.0')
+    from gi.repository import Gtk, WebKit2, GLib
 except ImportError:
     try:
         import pgi as gi
+        gi.require_version('Gtk', '3.0')
+        gi.require_version('WebKit2', '4.0')
+        from pgi.repository import Gtk, WebKit2, GLib
     except ImportError:
         gi = None
 if gi is None:
@@ -23,10 +29,6 @@ from shlex import quote
 from sys import stderr, platform
 from binascii import a2b_base64, b2a_base64
 from urllib.parse import urlparse, urlencode
-
-gi.require_version('Gtk', '3.0')
-gi.require_version('WebKit2', '4.0')
-from gi.repository import Gtk, WebKit2, GLib
 
 class SAMLLoginView:
     def __init__(self, uri, html=None, verbose=False, cookies=None, verify=True):


### PR DESCRIPTION
The name can't be an alias when importing from `from module.submodule`

Related to https://github.com/dlenski/gp-saml-gui/issues/7

```
~ » ipython
Python 3.7.1 (tags/v3.7.1:260ec2c36a, Nov 11 2018, 14:02:23) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.3.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import pgi as gi                

In [2]: from gi import Gtk              
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
<ipython-input-2-bfc4536cdcdd> in <module>
----> 1 from gi import Gtk

ModuleNotFoundError: No module named 'gi'
```