### PR TITLE
Update OpenConnect cmd Line invocation to use sudo

### DIFF
--- a/gp-saml-gui.py
+++ b/gp-saml-gui.py
@@ -274,7 +274,7 @@ if __name__ == "__main__":
                   '''that's often associated with the {} interface. You should probably try both.\n'''.format(args.interface, ifh),
                   file=stderr)
         print('''\nSAML response converted to OpenConnect command line invocation:\n''', file=stderr)
-        print('''    echo {} |\n        openconnect --protocol=gp --user={} --os={} --usergroup={}:{} --passwd-on-stdin {}'''.format(
+        print('''    echo {} |\n       sudo openconnect --protocol=gp --user={} --os={} --usergroup={}:{} --passwd-on-stdin {}'''.format(
             quote(cv), quote(un), quote(args.ocos), quote(args.interface), quote(cn), quote(server)), file=stderr)
 
         print('''\nSAML response converted to test-globalprotect-login.py invocation:\n''', file=stderr)

--- a/gp-saml-gui.py
+++ b/gp-saml-gui.py
@@ -274,7 +274,7 @@ if __name__ == "__main__":
                   '''that's often associated with the {} interface. You should probably try both.\n'''.format(args.interface, ifh),
                   file=stderr)
         print('''\nSAML response converted to OpenConnect command line invocation:\n''', file=stderr)
-        print('''    echo {} |\n       sudo openconnect --protocol=gp --user={} --os={} --usergroup={}:{} --passwd-on-stdin {}'''.format(
+        print('''    echo {} |\n        sudo openconnect --protocol=gp --user={} --os={} --usergroup={}:{} --passwd-on-stdin {}'''.format(
             quote(cv), quote(un), quote(args.ocos), quote(args.interface), quote(cn), quote(server)), file=stderr)
 
         print('''\nSAML response converted to test-globalprotect-login.py invocation:\n''', file=stderr)


### PR DESCRIPTION
This small change just adds a 'sudo' prefix to 'SAML response converted to OpenConnect command line invocation' because OpenConnect requires root privileges. Otherwise, blind copy-paste will result in an error so you have to authenticate again