### PR TITLE
Add Gtk.init() before start using Gtk functions

### DIFF
--- a/gp_saml_gui.py
+++ b/gp_saml_gui.py
@@ -33,6 +33,7 @@ from urllib.parse import urlparse, urlencode
 
 class SAMLLoginView:
     def __init__(self, uri, html=None, verbose=False, cookies=None, verify=True):
+        Gtk.init()
         window = Gtk.Window()
 
         # API reference: https://lazka.github.io/pgi-docs/#WebKit2-4.0


### PR DESCRIPTION
As per this doc https://valadoc.org/gtk+-3.0/Gtk.init.html

Call this (`Gtk.init()`) function before using any other GTK+ functions in your GUI applications.

--

Without calling this function, it will break in OpenSUSE

```
$ python3 gp_saml_gui.py --no-verify --clientos=Linux x.x.x.x                                                                                                                   git(gtk-opensuse-fix|) 
Looking for SAML auth tags in response to https://x.x.x.x/ssl-vpn/prelogin.esp...
/home/zaki/.local/lib/python3.6/site-packages/urllib3/connectionpool.py:1020: InsecureRequestWarning: Unverified HTTPS request is being made to host 'x.x.x.x'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning,
Got SAML POST, opening browser...

(process:1585): Gtk-CRITICAL **: 16:05:47.337: _gtk_style_provider_private_get_settings: assertion 'GTK_IS_STYLE_PROVIDER_PRIVATE (provider)' failed

(process:1585): Gtk-CRITICAL **: 16:05:47.337: _gtk_style_provider_private_get_settings: assertion 'GTK_IS_STYLE_PROVIDER_PRIVATE (provider)' failed

(process:1585): Gtk-CRITICAL **: 16:05:47.337: _gtk_style_provider_private_get_settings: assertion 'GTK_IS_STYLE_PROVIDER_PRIVATE (provider)' failed
[1]    1585 segmentation fault (core dumped)  python3 gp_saml_gui.py --no-verify --clientos=Linux x.x.x.x
```

After adding `Gtk.init()`

```
$ python3 gp_saml_gui.py --no-verify --clientos=Linux x.x.x.x                                                                                                                      git(gtk-opensuse-fix|) 
Looking for SAML auth tags in response to https://x.x.x.x/ssl-vpn/prelogin.esp...
/home/zaki/.local/lib/python3.6/site-packages/urllib3/connectionpool.py:1020: InsecureRequestWarning: Unverified HTTPS request is being made to host 'x.x.x.x'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning,
Got SAML POST, opening browser...

(process:7586): Gtk-WARNING **: 16:15:44.440: Locale not supported by C library.
        Using the fallback 'C' locale.

(process:7607): Gtk-WARNING **: 16:15:44.732: Locale not supported by C library.
        Using the fallback 'C' locale.
[PAGE   ] Finished loading page about:blank
[PAGE   ] Finished loading page https://x.okta.com/app/gp/xxx/sso/saml
Login window closed by user.
```