### PR TITLE
Cisco anyconnect webvpn cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Table of Contents
 Introduction
 ============
 
-This is a helper script to allow you to interactively login to a GlobalProtect VPN
+This is a helper script to allow you to interactively login to a GlobalProtect or AnyConnect VPN
 that uses [SAML](https://en.wikipedia.org/wiki/Security_Assertion_Markup_Language)
 authentication, so that you can subsequently connect with [OpenConnect](https://www.infradead.org/openconnect).
 (The GlobalProtect protocol is supported in OpenConnect v8.0 or newer; v8.06+ is recommended.)
@@ -81,6 +81,9 @@ gp-saml-gui: error: the following arguments are required: server, openconnect_ex
 How to use
 ==========
 
+GlobalProtect
+-------------
+
 Specify the GlobalProtect server URL (portal or gateway) and optional
 arguments, such as `--clientos=Windows` (because many GlobalProtect
 servers don't require SAML login, but apparently omit it in their configuration
@@ -115,6 +118,26 @@ win
 
 $ echo "$COOKIE" | openconnect --protocol=gp -u "$USER" --os="$OS" --passwd-on-stdin "$HOST"
 ```
+
+Cisco AnyConnect
+----------------
+
+[Cisco AnyConnect](https://www.infradead.org/openconnect/anyconnect.html)
+returns the SAML authentication in the `webvpn` cookie,
+which is extracted from the SAML response when available.
+
+Invoke as following, e.g as part of a bash script
+
+```bash
+SAML_COOKIE=$(gp_saml_gui --no-cookies --uri vpn.company.com/saml | perl -ne "/^COOKIE='?(.+)'?$/ && print \$1;")
+openconnect --cookie-on-stdin $LOGIN_URL_SAML <<< "$SAML_COOKIE"
+```
+
+You can also automatically invoke OpenConnect as described in the next section.
+
+
+OpenConnect Invocation
+----------------------
 
 If you specify either the `-P`/`--pkexec-openconnect` or `-S`/`--sudo-openconnect` options, the script
 will automatically invoke OpenConnect as described, using either [`pkexec` from Polkit](https://www.freedesktop.org/software/polkit/docs/0.106/polkit.8.html)

--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ which is extracted from the SAML response when available.
 Invoke as following, e.g as part of a bash script
 
 ```bash
-SAML_COOKIE=$(gp_saml_gui --no-cookies --uri vpn.company.com/saml | perl -ne "/^COOKIE='?(.+)'?$/ && print \$1;")
+LOGIN_URL_SAML=vpn.company.com/saml
+SAML_COOKIE=$(gp_saml_gui --no-cookies --uri $LOGIN_URL_SAML | perl -ne "/^COOKIE='?(.+)'?$/ && print \$1;")
 openconnect --cookie-on-stdin $LOGIN_URL_SAML <<< "$SAML_COOKIE"
 ```
 

--- a/gp-saml-gui.8
+++ b/gp-saml-gui.8
@@ -1,6 +1,6 @@
 .TH gp-saml-gui 8 2020-12-28 "gp-saml-gui"
 .SH NAME
-gp-saml-gui \- login to a GlobalProtect VPN that uses SAML authentication
+gp-saml-gui \- login to a GlobalProtect or AnyConnect VPN that uses SAML authentication
 .SH SYNOPSIS
 .SY gp-saml-gui
 .OP -h
@@ -26,7 +26,7 @@ gp-saml-gui \- login to a GlobalProtect VPN that uses SAML authentication
 
 .SH DESCRIPTION
 This is a helper script to allow you to interactively login to a
-GlobalProtect VPN that uses SAML authentication, so that you can
+GlobalProtect or AnyConnect VPN that uses SAML authentication, so that you can
 subsequently connect with OpenConnect.
 
 Some GlobalProtect VPNs which use SAML authentication are amenable
@@ -40,7 +40,7 @@ alternative for some VPNs.
 .I Positional arguments
 .IP
 .B server
-Hostname or IP address of GlobalProtect server (portal or gateway)
+Hostname or IP address of GlobalProtect or AnyConnect server (portal or gateway)
 .IP
 .B openconnect_extra
 Extra arguments to include in output OpenConnect command-line (these should be preceded by
@@ -56,10 +56,10 @@ Show help message and exit
 Ignore invalid server certificate
 .IP
 .B -C, --cookies
-Use and store cookies in this file
+Store cookies in this file
 .IP
 .B -K, --no-cookies
-Don't use or store cookies at all
+Don't store cookies at all
 .IP
 .B -g, --gateway
 SAML auth to gateway

--- a/gp_saml_gui.py
+++ b/gp_saml_gui.py
@@ -158,7 +158,7 @@ def parse_args(args = None):
     default_clientos = pf2clientos.get(platform, 'Windows')
 
     p = argparse.ArgumentParser()
-    p.add_argument('server', help='GlobalProtect server (portal or gateway)')
+    p.add_argument('server', help='GlobalProtect or AnyConnect server (portal or gateway)')
     p.add_argument('--no-verify', dest='verify', action='store_false', default=True, help='Ignore invalid server certificate')
     x = p.add_mutually_exclusive_group()
     x.add_argument('-C', '--cookies', default='~/.gp-saml-gui-cookies',

--- a/gp_saml_gui.py
+++ b/gp_saml_gui.py
@@ -175,7 +175,7 @@ def parse_args(args = None):
     g.add_argument('--key', help='PEM file containing client private key (if not included in same file as certificate)')
     g = p.add_argument_group('Debugging and advanced options')
     x = p.add_mutually_exclusive_group()
-    x.add_argument('-v','--verbose', default=1, action='count', help='Increase verbosity of explanatory output to stderr')
+    x.add_argument('-v','--verbose', default=0, action='count', help='Increase verbosity of explanatory output to stderr')
     x.add_argument('-q','--quiet', dest='verbose', action='store_const', const=0, help='Reduce verbosity to a minimum')
     x = p.add_mutually_exclusive_group()
     x.add_argument('-x','--external', action='store_true', help='Launch external browser (for debugging)')

--- a/gp_saml_gui.py
+++ b/gp_saml_gui.py
@@ -41,14 +41,16 @@ class SAMLLoginView:
         self.closed = False
         self.success = False
         self.saml_result = {}
+        self.webvpn = None
         self.verbose = verbose
 
         self.ctx = WebKit2.WebContext.get_default()
         if not verify:
             self.ctx.set_tls_errors_policy(WebKit2.TLSErrorsPolicy.IGNORE)
         self.cookies = self.ctx.get_cookie_manager()
+        self.cookies.set_accept_policy(WebKit2.CookieAcceptPolicy.ALWAYS)
         if cookies:
-            self.cookies.set_accept_policy(WebKit2.CookieAcceptPolicy.ALWAYS)
+            # Persistent cookie storage requested
             self.cookies.set_persistent_storage(cookies, WebKit2.CookiePersistentStorage.TEXT)
         self.wview = WebKit2.WebView()
 
@@ -105,6 +107,8 @@ class SAMLLoginView:
         uri = mr.get_uri()
         rs = mr.get_response()
         h = rs.get_http_headers() if rs else None
+        # Request cookies from this page
+        self.cookies.get_cookies(uri, None, self.cookie_callback, uri)
         if self.verbose:
             print('[PAGE   ] Finished loading page %s' % uri, file=stderr)
         if not h:
@@ -126,11 +130,25 @@ class SAMLLoginView:
         self.saml_result.update(fd, server=urlparse(uri).netloc)
         GLib.timeout_add(1000, self.check_done)
 
+    def cookie_callback(self, cookiemanager, result, uri):
+        # Invoked from get_saml_headers
+        # Cookes are now available and can be fetched
+        self.current_cookies = {}
+        for c in cookiemanager.get_cookies_finish(result):
+            if c.get_name() == "webvpn":
+                self.webvpn = c.get_value()
+                break
+
     def check_done(self):
         d = self.saml_result
         if 'saml-username' in d and ('prelogin-cookie' in d or 'portal-userauthcookie' in d):
             if self.verbose:
                 print("[SAML   ] Got all required SAML headers, done.", file=stderr)
+            self.success = True
+            Gtk.main_quit()
+        if self.webvpn:
+            if self.verbose:
+                print(f"[SAML   ] Got webvpn cookie: {self.webvpn}", file=stderr)
             self.success = True
             Gtk.main_quit()
 
@@ -144,9 +162,9 @@ def parse_args(args = None):
     p.add_argument('--no-verify', dest='verify', action='store_false', default=True, help='Ignore invalid server certificate')
     x = p.add_mutually_exclusive_group()
     x.add_argument('-C', '--cookies', default='~/.gp-saml-gui-cookies',
-                   help='Use and store cookies in this file (instead of default %(default)s)')
+                   help='Store cookies in this file (instead of default %(default)s)')
     x.add_argument('-K', '--no-cookies', dest='cookies', action='store_const', const=None,
-                   help="Don't use or store cookies at all")
+                   help="Don't store cookies at all")
     x = p.add_mutually_exclusive_group()
     x.add_argument('-g','--gateway', dest='interface', action='store_const', const='gateway', default='portal',
                    help='SAML auth to gateway')
@@ -269,25 +287,39 @@ def main(args = None):
         p.error('''Login window closed without producing SAML cookies.''')
 
     # extract response and convert to OpenConnect command-line
-    un = slv.saml_result.get('saml-username')
-    server = slv.saml_result.get('server', args.server)
+    if slv.webvpn:
+        # When a Anyconnect webvpn cookie is available, use this to connect.
+        # No other information besides the url is needed by openconnect
+        cv = slv.webvpn
+        server = args.server
+        un = cn = ifh = None
+        openconnect_args = [
+            "--protocol=anyconnect",
+            "--cookie-on-stdin",
+            server
+        ]
+    else: # not slv.webvpn, more information is needed
+        un = slv.saml_result.get('saml-username')
+        server = slv.saml_result.get('server', args.server)
 
-    for cn, ifh in (('prelogin-cookie','gateway'), ('portal-userauthcookie','portal')):
-        cv = slv.saml_result.get(cn)
-        if cv:
-            break
-    else:
-        cn = ifh = None
-        p.error("Didn't get an expected cookie. Something went wrong.")
+        for cn, ifh in (('prelogin-cookie','gateway'), ('portal-userauthcookie','portal')):
+            cv = slv.saml_result.get(cn)
+            if cv:
+                break
+            else:
+                cn = ifh = None
+                p.error("Didn't get an expected cookie. Something went wrong.")
 
-    openconnect_args = [
-        "--protocol=gp",
-        "--user="+un,
-        "--os="+args.ocos,
-        "--usergroup="+args.interface+":"+cn,
-        "--passwd-on-stdin",
-        server
-    ] + args.openconnect_extra
+        openconnect_args = [
+            "--protocol=gp",
+            "--user="+un,
+            "--os="+args.ocos,
+            "--usergroup="+args.interface+":"+cn,
+            "--passwd-on-stdin",
+            server
+        ]
+    # end if slv.webvpn:
+    openconnect_args += args.openconnect_extra
 
     openconnect_command = '''    echo {} |\n        sudo openconnect {}'''.format(
         quote(cv), " ".join(map(quote, openconnect_args)))
@@ -305,9 +337,10 @@ def main(args = None):
         print('''\nSAML response converted to OpenConnect command line invocation:\n''', file=stderr)
         print(openconnect_command, file=stderr)
 
-        print('''\nSAML response converted to test-globalprotect-login.py invocation:\n''', file=stderr)
-        print('''    test-globalprotect-login.py --user={} --clientos={} -p '' \\\n         https://{}/{} {}={}\n'''.format(
-            quote(un), quote(args.clientos), quote(server), quote(if2auth[args.interface]), quote(cn), quote(cv)), file=stderr)
+        if not slv.webvpn:
+            print('''\nSAML response converted to test-globalprotect-login.py invocation:\n''', file=stderr)
+            print('''    test-globalprotect-login.py --user={} --clientos={} -p '' \\\n         https://{}/{} {}={}\n'''.format(
+                quote(un), quote(args.clientos), quote(server), quote(if2auth[args.interface]), quote(cn), quote(cv)), file=stderr)
 
     if args.exec:
         print('''Launching OpenConnect with {}, equivalent to:\n{}'''.format(args.exec, openconnect_command))


### PR DESCRIPTION
### Add support for Cisco AnyConnect SAML VPN

which returns the authentication cookie within the `webvpn` cookie.

I hope I did not broke anything else, unfortunately as I don't have other VPNs available I was unable to test it.  
If you want to pick up my change and need to make modifications, then I'll of course help with testing it versus the AnyConnect functionality.

Thanks for your work, it was (is) a great base to get AnyConnect SAML running!