### PR TITLE
Gtk.init() requires a parameter on some platforms

### DIFF
--- a/gp_saml_gui.py
+++ b/gp_saml_gui.py
@@ -33,7 +33,7 @@ from urllib.parse import urlparse, urlencode
 
 class SAMLLoginView:
     def __init__(self, uri, html=None, verbose=False, cookies=None, verify=True):
-        Gtk.init()
+        Gtk.init(None)
         window = Gtk.Window()
 
         # API reference: https://lazka.github.io/pgi-docs/#WebKit2-4.0


### PR DESCRIPTION
Fixes #39.

The documentation does specify an argv parameter ([str] or None):
https://lazka.github.io/pgi-docs/Gtk-3.0/functions.html#Gtk.init

The required parameters may depend on the version of some components. If so, the solution might be:
```python
        try:
            Gtk.init()
        except TypeError:
            Gtk.init(None)
```
But for now I suggest we stick to the documentation.