### PR TITLE
Autofill credentials in the SAML window from ini file

### DIFF
--- a/gp_saml_gui.py
+++ b/gp_saml_gui.py
@@ -146,7 +146,10 @@ class SAMLLoginView:
 
     def setvalue_DOM_element(self, selector, value):
         if self.wview:
-            # 
+            # name attibute
+            self.wview.evaluate_javascript("Array.from(document.getElementsByName(%s)).forEach(el => el.value = %s);" % (json.dumps(selector), json.dumps(value)), -1, None, None, None, None, None)
+            
+            # id attribute 
             self.wview.evaluate_javascript("document.getElementById(%s).value = %s;" % (json.dumps(selector), json.dumps(value)), -1, None, None, None, None, None)
 
     def on_load_changed(self, webview, event):

--- a/gp_saml_gui.py
+++ b/gp_saml_gui.py
@@ -84,18 +84,18 @@ class SAMLLoginView:
         settings.set_user_agent(args.user_agent)
         self.wview.set_settings(settings)
 
-        if args.credentials:
-            self.credentials = {}
+        if args.login:
+            self.login = {}
             config = configparser.ConfigParser()
             try:
-                with open(args.credentials) as fp:
-                    config.read_file(itertools.chain(["[gp-saml-gui]\n"], fp), source=args.credentials)
+                with open(args.login) as fp:
+                    config.read_file(itertools.chain(["[gp-saml-gui]\n"], fp), source=args.login)
             except:
-                print("Error opening '%s'" % args.credentials)
+                print("Error opening or reading '%s'" % args.login)
                 config = None
             if config:
                 for x in ['username', 'password']:
-                    self.credentials[x] = config['gp-saml-gui'][x]
+                    self.login[x] = config['gp-saml-gui'][x]
 
         window.resize(500, 500)
         window.add(self.wview)
@@ -167,9 +167,9 @@ class SAMLLoginView:
         if not rs or not h:
             return
 
-        # Set credentials
-        for x in self.credentials:
-            self.setvalue_DOM_element(x, self.credentials[x])
+        # Set login credentials
+        for x in self.login:
+            self.setvalue_DOM_element(x, self.login[x])
         
         # convert to normal dict
         d = {}
@@ -313,7 +313,7 @@ def parse_args(args = None):
     g.add_argument('-u','--uri', action='store_true', help='Treat server as the complete URI of the SAML entry point, rather than GlobalProtect server')
     g.add_argument('--clientos', choices=set(pf2clientos.values()), default=default_clientos, help="clientos value to send (default is %(default)s)")
     p.add_argument('-l','--login', default='~/.gp-saml-gui-credentials',
-                   help='Read login credentials in this file (instead of default %(default)s)')
+                   help='Read login credentials from the file specified (instead of default %(default)s)')
     p.add_argument('-f','--field', dest='extra', action='append', default=[],
                    help='Extra form field(s) to pass to include in the login query string (e.g. "-f magic-cookie-value=deadbeef01234567")')
     p.add_argument('--allow-insecure-crypto', dest='insecure', action='store_true',

--- a/gp_saml_gui.py
+++ b/gp_saml_gui.py
@@ -85,6 +85,7 @@ class SAMLLoginView:
         self.wview.set_settings(settings)
 
         if args.login:
+            args.login = path.expanduser(args.login)
             self.login = {}
             config = configparser.ConfigParser()
             try:

--- a/gp_saml_gui.py
+++ b/gp_saml_gui.py
@@ -94,7 +94,7 @@ class SAMLLoginView:
                 print("Error opening or reading '%s'" % args.login)
                 config = None
             if config and config.has_section(args.server):
-                for x in ['username', 'password']:
+                for x in config[args.server]:
                     self.login[x] = config[args.server][x]
 
         window.resize(500, 500)

--- a/gp_saml_gui.py
+++ b/gp_saml_gui.py
@@ -93,9 +93,9 @@ class SAMLLoginView:
             except:
                 print("Error opening or reading '%s'" % args.login)
                 config = None
-            if config:
+            if config and config.has_section(args.server):
                 for x in ['username', 'password']:
-                    self.login[x] = config['gp-saml-gui'][x]
+                    self.login[x] = config[args.server][x]
 
         window.resize(500, 500)
         window.add(self.wview)

--- a/gp_saml_gui.py
+++ b/gp_saml_gui.py
@@ -31,6 +31,7 @@ import ssl
 import tempfile
 import configparser
 import itertools
+import json
 
 from operator import setitem
 from os import path, dup2, execvp, environ
@@ -145,7 +146,8 @@ class SAMLLoginView:
 
     def setvalue_DOM_element(self, selector, value):
         if self.wview:
-            self.wview.evaluate_javascript("document.getElementById('" + selector + "').value='" + value + "';", -1, None, None, None, None, None)
+            # 
+            self.wview.evaluate_javascript("document.getElementById(%s).value = %s;" % (json.dumps(selector), json.dumps(value)), -1, None, None, None, None, None)
 
     def on_load_changed(self, webview, event):
         if event != WebKit2.LoadEvent.FINISHED:

--- a/gp_saml_gui.py
+++ b/gp_saml_gui.py
@@ -89,8 +89,7 @@ class SAMLLoginView:
             self.login = {}
             config = configparser.ConfigParser()
             try:
-                with open(args.login) as fp:
-                    config.read_file(itertools.chain(["[gp-saml-gui]\n"], fp), source=args.login)
+                config.read(args.login)
             except:
                 print("Error opening or reading '%s'" % args.login)
                 config = None


### PR DESCRIPTION
This allows one to autofill credentials in the SAML window from ini file.
Default is "~/.gp-saml-gui-credentials", can be specified with "--login" command line argument.

Mode of the credential file should be set the to 600 (similarly to .git-credentials, .ssh/id_rsa, ...).