### PR TITLE
Switch from webkit2gtk 4.0 to 4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ First, non-Python Dependencies
 gp-saml-gui uses GTK, which requires Python 3 bindings.
 
 On Debian / Ubuntu, these are packaged as `python3-gi`, `gir1.2-gtk-3.0`, and
-`gir1.2-webkit2-4.0`:
+`gir1.2-webkit2-4.1`:
 
 ```
-$ sudo apt install python3-gi gir1.2-gtk-3.0 gir1.2-webkit2-4.0
+$ sudo apt install python3-gi gir1.2-gtk-3.0 gir1.2-webkit2-4.1
 ```
 
 On Fedora (and possibly RHEL/CentOS) the matching libraries are packaged in

--- a/gp_saml_gui.py
+++ b/gp_saml_gui.py
@@ -3,13 +3,13 @@
 try:
     import gi
     gi.require_version('Gtk', '3.0')
-    gi.require_version('WebKit2', '4.0')
+    gi.require_version('WebKit2', '4.1')
     from gi.repository import Gtk, WebKit2, GLib
 except ImportError:
     try:
         import pgi as gi
         gi.require_version('Gtk', '3.0')
-        gi.require_version('WebKit2', '4.0')
+        gi.require_version('WebKit2', '4.1')
         from pgi.repository import Gtk, WebKit2, GLib
     except ImportError:
         gi = None
@@ -49,7 +49,7 @@ class SAMLLoginView:
         Gtk.init(None)
         window = Gtk.Window()
 
-        # API reference: https://lazka.github.io/pgi-docs/#WebKit2-4.0
+        # API reference: https://lazka.github.io/pgi-docs/#WebKit2-4.1
 
         self.closed = False
         self.success = False


### PR DESCRIPTION
webkit2gtk 4.1 is the same as 4.0 except that 4.1 uses libsoup3 and 4.0 uses libsoup2.4. Since your project doesn't use libsoup directly, this is an easy swap.

Every distro with current webkitgtk support should have the 4.1 packages including Debian 12 and Ubuntu 22.04 LTS.

Fedora has [stopped](https://fedoraproject.org/wiki/Changes/Remove_webkit2gtk-4.0_API_Version) building the 4.0 packages in preparation for their Fedora 40 release in a few months. Debian and Ubuntu are working on removing 4.0 also.