### PR TITLE
add an option to use gateway hostname as server

### DIFF
--- a/gp-saml-gui.8
+++ b/gp-saml-gui.8
@@ -65,6 +65,9 @@ Don't use or store cookies at all
 .B -g, --gateway
 SAML auth to gateway
 .IP
+.B -i, --ignore-redirects
+Use specified gateway hostname as server, ignoring redirects
+.IP
 .B -p, --portal
 SAML auth to portal (default)
 .IP


### PR DESCRIPTION
For some gateways, we get a message from gp-saml-gui: IMPORTANT: During the SAML auth, you were redirected from [...]

gp-saml-gui uses the target of the redirect, but this is not always correct. Add an option to direct gp-saml-gui to ignore the redirect.