### PR TITLE
Add a new --disable-proxy argument

### DIFF
--- a/gp_saml_gui.py
+++ b/gp_saml_gui.py
@@ -45,7 +45,7 @@ COOKIE_FIELDS = ('prelogin-cookie', 'portal-userauthcookie')
 
 
 class SAMLLoginView:
-    def __init__(self, uri, html=None, verbose=False, cookies=None, verify=True, user_agent=None):
+    def __init__(self, uri, html=None, verbose=False, cookies=None, verify=True, user_agent=None, disable_proxy=False):
         Gtk.init(None)
         window = Gtk.Window()
 
@@ -57,6 +57,8 @@ class SAMLLoginView:
         self.verbose = verbose
 
         self.ctx = WebKit2.WebContext.get_default()
+        if disable_proxy:
+            self.ctx.get_website_data_manager().set_network_proxy_settings(WebKit2.NetworkProxyMode.NO_PROXY, None)
         if not verify:
             self.ctx.set_tls_errors_policy(WebKit2.TLSErrorsPolicy.IGNORE)
         self.cookies = self.ctx.get_cookie_manager()
@@ -259,6 +261,8 @@ def parse_args(args = None):
                    help='Allow use of insecure renegotiation or ancient 3DES and RC4 ciphers')
     p.add_argument('--user-agent', '--useragent', default='PAN GlobalProtect',
                    help='Use the provided string as the HTTP User-Agent header (default is %(default)r, as used by OpenConnect)')
+    p.add_argument('--disable-proxy', dest='disable_proxy', action='store_true',
+                   help='Do not use system-wide proxies in WebViews, if set')
     p.add_argument('openconnect_extra', nargs='*', help="Extra arguments to include in output OpenConnect command-line")
     args = p.parse_args(args)
 
@@ -354,7 +358,7 @@ def main(args = None):
     # spawn WebKit view to do SAML interactive login
     if args.verbose:
         print("Got SAML %s, opening browser..." % sam, file=stderr)
-    slv = SAMLLoginView(uri, html, verbose=args.verbose, cookies=args.cookies, verify=args.verify, user_agent=args.user_agent)
+    slv = SAMLLoginView(uri, html, verbose=args.verbose, cookies=args.cookies, verify=args.verify, user_agent=args.user_agent, disable_proxy=args.disable_proxy)
     Gtk.main()
     if slv.closed:
         print("Login window closed by user.", file=stderr)


### PR DESCRIPTION
In our company, we have a mandatory HTTP(S) proxy to leave the internal network, but the proxy gateway is available only within that internal network - on most systems this is configured with `HTTP/HTTPS/NO_PROXY` environment variables. For some reason, WebViews ignore NO_PROXY vars and resolve the proxy address to access the VPN gateway, which fails since we're not on the VPN in the first place...

This PR allows disabling proxies in WebViews for systems configured to go through the proxy with a new `--disable-proxy` argument, but unable to access it from the outside of the VPN. Note that this affect the WebView only - requests/urllib3/etc will still use it if you don't have the correct NO_PROXY value to make them ignore the proxy for gateways.