### PR TITLE
TLSAdapter bugfixes

### DIFF
--- a/gp_saml_gui.py
+++ b/gp_saml_gui.py
@@ -24,7 +24,7 @@ import ssl
 import tempfile
 
 from operator import setitem
-from os import path, dup2, execvp
+from os import path, dup2, execvp, environ
 from shlex import quote
 from sys import stderr, platform
 from binascii import a2b_base64, b2a_base64
@@ -216,6 +216,10 @@ class TLSAdapter(requests.adapters.HTTPAdapter):
         ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         ssl_context.set_ciphers('DEFAULT:@SECLEVEL=1')
         ssl_context.options |= 1<<2  # OP_LEGACY_SERVER_CONNECT
+        if hasattr(ssl_context, "keylog_filename"):
+            sslkeylogfile = environ.get("SSLKEYLOGFILE")
+            if sslkeylogfile:
+                ssl_context.keylog_filename = sslkeylogfile
         self.poolmanager = urllib3.PoolManager(
                 num_pools=connections,
                 maxsize=maxsize,

--- a/gp_saml_gui.py
+++ b/gp_saml_gui.py
@@ -212,10 +212,16 @@ class TLSAdapter(requests.adapters.HTTPAdapter):
     We have extracted the relevant value from <openssl/ssl.h>.
 
     '''
+
+    def __init__(self, verify=True):
+        self.verify = verify
+        super().__init__()
+
     def init_poolmanager(self, connections, maxsize, block=False):
         ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         ssl_context.set_ciphers('DEFAULT:@SECLEVEL=1')
         ssl_context.options |= 1<<2  # OP_LEGACY_SERVER_CONNECT
+        ssl_context.check_hostname = self.verify
         if hasattr(ssl_context, "keylog_filename"):
             sslkeylogfile = environ.get("SSLKEYLOGFILE")
             if sslkeylogfile:
@@ -288,7 +294,7 @@ def main(args = None):
 
     s = requests.Session()
     if args.insecure:
-        s.mount('https://', TLSAdapter())
+        s.mount('https://', TLSAdapter(verify=args.verify))
     s.headers['User-Agent'] = 'PAN GlobalProtect' if args.user_agent is None else args.user_agent
     s.cert = args.cert
 

--- a/gp_saml_gui.py
+++ b/gp_saml_gui.py
@@ -221,11 +221,16 @@ class TLSAdapter(requests.adapters.HTTPAdapter):
         ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         ssl_context.set_ciphers('DEFAULT:@SECLEVEL=1')
         ssl_context.options |= 1<<2  # OP_LEGACY_SERVER_CONNECT
-        ssl_context.check_hostname = self.verify
+
+        if not self.verify:
+            ssl_context.check_hostname = False
+            ssl_context.verify_mode = ssl.CERT_NONE
+
         if hasattr(ssl_context, "keylog_filename"):
             sslkeylogfile = environ.get("SSLKEYLOGFILE")
             if sslkeylogfile:
                 ssl_context.keylog_filename = sslkeylogfile
+
         self.poolmanager = urllib3.PoolManager(
                 num_pools=connections,
                 maxsize=maxsize,


### PR DESCRIPTION
when the `--allow-insecure-ciphers` option is used, we register our own HTTPAdapter which overrides the `ssl_context` used by connections.

we need to do this in order to control the options and ciphers, but this bypasses the urllib3's [`create_urllib3_context`](https://github.com/urllib3/urllib3/blob/b7c2910a9f49ba0d58c8d4381500c208f9a24765/src/urllib3/util/ssl_.py#L216) logic, which leads to some features not working when `--allow-insecure-ciphers` is in place.

this PR replicates some of that logic to fix it; see each commit for explanation and references.