### PR TITLE
fix exception when checking about:blank response

### DIFF
--- a/gp_saml_gui.py
+++ b/gp_saml_gui.py
@@ -124,10 +124,14 @@ class SAMLLoginView:
         uri = mr.get_uri()
         rs = mr.get_response()
         h = rs.get_http_headers() if rs else None
-        ct = h.get_content_type()
+        ct = h.get_content_type() if h else None
 
         if self.verbose:
             print('[PAGE   ] Finished loading page %s' % uri, file=stderr)
+
+        # if no response or no headers (for e.g. about:blank), skip checking this
+        if not rs or not h:
+            return
 
         # convert to normal dict
         d = {}


### PR DESCRIPTION
at some point, auth loads `about:blank` and (since there's no response) an exception occurs:

~~~
Traceback (most recent call last):
  File "gp_saml_gui.py", line 127, in on_load_changed
    ct = h.get_content_type()
         ^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get_content_type'
~~~

the current code doesn't make much sense -- if an HTTP response is not present, it sets 'h' to None... but then proceeds to do stuff with 'h' assuming it has some value.