### PR TITLE
add -E / --exec-openconnect

### DIFF
--- a/gp-saml-gui.8
+++ b/gp-saml-gui.8
@@ -16,6 +16,7 @@ gp-saml-gui \- login to a GlobalProtect VPN that uses SAML authentication
 .OP -x
 .OP -P
 .OP -S
+.OP -E
 .OP -u
 .OP --clientos {Windows,Linux,Mac}
 .OP -f EXTRA
@@ -81,6 +82,9 @@ Use PolicyKit (\fBpkexec\fR) to exec openconnect
 .IP
 .B -S, --sudo-openconnect
 Use sudo to exec openconnect
+.IP
+.B -E, --exec-openconnect
+Execute openconnect directly (advanced users)
 .IP
 .B -f, --field
 Extra form field(s) to pass to include in the login query string

--- a/gp_saml_gui.py
+++ b/gp_saml_gui.py
@@ -251,6 +251,7 @@ def parse_args(args = None):
     x.add_argument('-x','--external', action='store_true', help='Launch external browser (for debugging)')
     x.add_argument('-P','--pkexec-openconnect', action='store_const', dest='exec', const='pkexec', help='Use PolicyKit to exec openconnect')
     x.add_argument('-S','--sudo-openconnect', action='store_const', dest='exec', const='sudo', help='Use sudo to exec openconnect')
+    x.add_argument('-E','--exec-openconnect', action='store_const', dest='exec', const='exec', help='Execute openconnect directly (advanced users)')
     g.add_argument('-u','--uri', action='store_true', help='Treat server as the complete URI of the SAML entry point, rather than GlobalProtect server')
     g.add_argument('--clientos', choices=set(pf2clientos.values()), default=default_clientos, help="clientos value to send (default is %(default)s)")
     p.add_argument('-f','--field', dest='extra', action='append', default=[],
@@ -423,10 +424,11 @@ def main(args = None):
             # redirect stdin from this file, before it is closed by the context manager
             # (it will remain accessible via the open file descriptor)
             dup2(tf.fileno(), 0)
+        cmd = ["openconnect"] + openconnect_args
         if args.exec == 'pkexec':
-            cmd = ["pkexec", "--user", "root", "openconnect"] + openconnect_args
+            cmd = ["pkexec", "--user", "root"] + cmd
         elif args.exec == 'sudo':
-            cmd = ["sudo", "openconnect"] + openconnect_args
+            cmd = ["sudo"] + cmd
         execvp(cmd[0], cmd)
 
     else:


### PR DESCRIPTION
in more advanced use cases, such as [ocproxy](https://github.com/cernekee/ocproxy), there's no need (and in fact, it is discouraged!) to elevate privileges when executing openconnect.

so, this adds an `-E / --exec-openconnect` option that execs openconnect directly without sudo or pkexec.